### PR TITLE
docs: update CLAUDE.md to reflect published image+feature architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 Template repository for Claude Code devcontainers. Provides a sandboxed Docker environment for running Claude with `--dangerously-skip-permissions`.
 
 ## Template Location
-`template/.devcontainer/` — copy to a project's `.devcontainer/` and customize per SETUP.md.
+`template/.devcontainer/` — the build source for the published Docker image (`ghcr.io/jasoncrawford/devcontainer-claude:latest`) and the devcontainer feature (`src/setup/`). Changes here take effect in consumer projects on their next rebuild after the publish workflow runs.
 
 ## Projects Using This Template
 - `~/projects/gh-agent`
@@ -11,7 +11,7 @@ Template repository for Claude Code devcontainers. Provides a sandboxed Docker e
 - `~/projects/site-status`
 - `~/projects/to-dont`
 
-When updating the template (Dockerfile, devcontainer.json, init-firewall.sh), apply the same changes to all four projects.
+These projects consume the published image and feature from ghcr.io. No manual file copying needed. Project-specific firewall domains live in each project's `.devcontainer/firewall-extras.txt`.
 
 ## Testing
 ```bash
@@ -31,4 +31,4 @@ CI runs `test-static.sh` on every push/PR via `.github/workflows/ci.yml`.
 
 **hadolint config**: The `.hadolint.yaml` documents suppressed rules, but hadolint 2.14.0 has a config auto-load bug. Inline `# hadolint ignore=` directives are used in the Dockerfile instead.
 
-**Firewall PROJECT DOMAINS**: The `# --- PROJECT DOMAINS ---` comment in `init-firewall.sh` sits inside the `for` loop. Add project-specific domains to the domain list before the closing `; do`.
+**Firewall extras**: Project-specific domains go in `.devcontainer/firewall-extras.txt` (one domain per line, `#` comments supported). The `init-firewall.sh` reads this file at container start from `/workspace/.devcontainer/firewall-extras.txt`.


### PR DESCRIPTION
Updates CLAUDE.md: template location clarified as build source, projects section updated to reflect published image+feature (no manual copying), firewall constraint updated to describe firewall-extras.txt approach.