### PR TITLE
fix: move auth token env vars from feature to consumer devcontainer.json

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -27,14 +27,16 @@ Copy and customize:
     "ghcr.io/jasoncrawford/devcontainer-claude/setup:1": {}
   },
   "containerEnv": {
-    "YOUR_PROJECT_TOKEN": "${localEnv:YOUR_PROJECT_TOKEN}"
+    "GH_TOKEN": "${localEnv:GH_TOKEN}",
+    "VERCEL_TOKEN": "${localEnv:VERCEL_TOKEN}",
+    "CLAUDE_CODE_OAUTH_TOKEN": "${localEnv:CLAUDE_CODE_OAUTH_TOKEN}"
   },
   "waitFor": "postStartCommand"
 }
 ```
 
 - Change `name` to match your project.
-- In `containerEnv`, include only tokens that are set on the host and needed in the container. Remove `YOUR_PROJECT_TOKEN` if you have none. The feature already provides `GH_TOKEN` and `VERCEL_TOKEN`.
+- The three `containerEnv` entries are required — they pass auth tokens from your host environment into the container in memory (no files). Add any project-specific tokens alongside them.
 - `remoteUser`, `workspaceMount`, `workspaceFolder`, and `waitFor` are the same for all projects — copy verbatim.
 
 ### 2. Add project-specific firewall domains (if needed)
@@ -76,7 +78,7 @@ Automatically, without any configuration in the project:
 
 - **Firewall** (`init-firewall.sh`): Restricts outbound traffic to an allowlist (GitHub, npm, Anthropic API, VS Code). Reads `.devcontainer/firewall-extras.txt` for project-specific domains.
 - **Mounts**: `.claude` volume (per project, keyed to devcontainerId), plus bind mounts for skills, commands, settings.json, projects, gitconfig, and `.claude-host`.
-- **Environment**: `NODE_OPTIONS`, `CLAUDE_CONFIG_DIR`, `GH_TOKEN`, `VERCEL_TOKEN`, `POWERLEVEL9K_DISABLE_GITSTATUS`.
+- **Environment**: `NODE_OPTIONS`, `CLAUDE_CONFIG_DIR`, `POWERLEVEL9K_DISABLE_GITSTATUS`. Auth tokens (`GH_TOKEN`, `VERCEL_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`) must be set in each project's `containerEnv` — the feature cannot inject host env vars at Docker build time.
 - **VS Code extensions**: Claude Code, ESLint, Prettier, GitLens.
 - **Lifecycle**: On create, runs `/usr/local/bin/post-create.sh` (seeds `.claude.json` from host, installs superpowers plugin). On start, runs `/usr/local/bin/post-start.sh` (runs the firewall script). Both scripts are baked into the base image.
 - **Capabilities**: `NET_ADMIN` and `NET_RAW` (required for iptables).

--- a/src/setup/devcontainer-feature.json
+++ b/src/setup/devcontainer-feature.json
@@ -51,10 +51,7 @@
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
-    "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
-    "GH_TOKEN": "${localEnv:GH_TOKEN}",
-    "VERCEL_TOKEN": "${localEnv:VERCEL_TOKEN}",
-    "CLAUDE_CODE_OAUTH_TOKEN": "${localEnv:CLAUDE_CODE_OAUTH_TOKEN}"
+    "POWERLEVEL9K_DISABLE_GITSTATUS": "true"
   },
   "customizations": {
     "vscode": {

--- a/test-static.sh
+++ b/test-static.sh
@@ -58,6 +58,18 @@ run "src/setup/devcontainer-feature.json is valid JSON" \
 run "src/setup/install.sh passes shellcheck" \
     shellcheck src/setup/install.sh
 
+# Feature containerEnv values are injected as ENV instructions in Dockerfile.extended
+# at Docker build time. ${localEnv:...} substitutions are NOT resolved at that phase —
+# they're only resolved for devcontainer.json-level containerEnv at container creation.
+# Using ${localEnv:...} in a feature's containerEnv causes a Docker BuildKit error.
+localenv_hits=$(jq -r '.containerEnv | to_entries[].value' src/setup/devcontainer-feature.json \
+    | grep -c "\${localEnv:" || true)
+if [[ "$localenv_hits" -gt 0 ]]; then
+    fail "feature containerEnv has ${localenv_hits} \${localEnv:...} value(s) — not resolved at Docker build time"
+else
+    pass "feature containerEnv has no \${localEnv:...} values"
+fi
+
 echo ""
 echo "=== Shell script linting (shellcheck) ==="
 run "template/init-firewall.sh" \


### PR DESCRIPTION
## Summary

- ${localEnv:...} in a feature's containerEnv is not resolved by the devcontainer CLI — values are injected verbatim as ENV instructions in Dockerfile.extended, causing Docker BuildKit to fail with 'unsupported modifier (:G) in substitution'. This is a known open bug (devcontainers/cli#308), unfixed in all CLI versions including 0.84.0.
- Removed GH_TOKEN, VERCEL_TOKEN, and CLAUDE_CODE_OAUTH_TOKEN from the feature's containerEnv. These must now live in each consumer project's devcontainer.json containerEnv, where ${localEnv:...} is correctly resolved in-memory at container creation time.
- Added a static test that catches ${localEnv:...} values in feature containerEnv.
- Updated SETUP.md to document the required snippet.

## Test plan

- [x] `./test-static.sh` passes (new test catches the bug, and passes after the fix)
- [ ] `ccnuke` in a consumer project completes without the BuildKit error
- [ ] Consumer project devcontainer.json files updated separately (outside this repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)