### PR TITLE
chore: bump feature version to 1.0.1 to trigger republish

### DIFF
--- a/src/setup/devcontainer-feature.json
+++ b/src/setup/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "setup",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Claude Code Sandbox Setup",
   "description": "Mounts, environment, firewall, and VS Code config for Claude Code devcontainers",
   "capAdd": ["NET_ADMIN", "NET_RAW"],


### PR DESCRIPTION
Version 1.0.0 was already published, so the publish workflow skipped it with a warning. Bumping to 1.0.1 so the fix from #6 actually gets published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)