### PR TITLE
feat: add claude-sdk-fix-libc helper for glibc containers

### DIFF
--- a/template/.devcontainer/Dockerfile
+++ b/template/.devcontainer/Dockerfile
@@ -89,9 +89,9 @@ RUN curl -fsSL https://claude.ai/install.sh | bash -s ${CLAUDE_CODE_CHANNEL}
 RUN npm install -g github:jasoncrawford/brunel
 
 # Copy and set up scripts
-COPY init-firewall.sh post-create.sh post-start.sh /usr/local/bin/
+COPY init-firewall.sh post-create.sh post-start.sh claude-sdk-fix-libc.sh /usr/local/bin/
 USER root
-RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/post-create.sh /usr/local/bin/post-start.sh && \
+RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/post-create.sh /usr/local/bin/post-start.sh /usr/local/bin/claude-sdk-fix-libc.sh && \
   echo "node ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/node-firewall && \
   chmod 0440 /etc/sudoers.d/node-firewall && \
   chown -R node:node /home/node/.claude

--- a/template/.devcontainer/claude-sdk-fix-libc.sh
+++ b/template/.devcontainer/claude-sdk-fix-libc.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Workaround for @anthropic-ai/claude-agent-sdk on glibc systems.
+#
+# The SDK's native-binary probe tries the musl variant first and only falls
+# back to the glibc variant if require.resolve() on the musl package throws.
+# The musl package manifests don't declare "libc": ["musl"], so npm installs
+# both variants on any Linux system — and the SDK then picks musl, which
+# fails its dynamic link against glibc, crashing the subprocess on first
+# write (EPIPE on the stdin socket).
+#
+# This image is always Debian/glibc (FROM node:20), so the musl variants are
+# never correct here. Remove them so the SDK's fallback picks the glibc binary.
+#
+# Projects that depend on @anthropic-ai/claude-agent-sdk should invoke this
+# in their postCreateCommand after npm ci, e.g.:
+#     "postCreateCommand": "npm ci && claude-sdk-fix-libc"
+#
+# Safe to run in projects that don't use the SDK — the glob is a no-op if the
+# paths don't exist.
+set -euo pipefail
+
+if [ -d node_modules/@anthropic-ai ]; then
+    rm -rf node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl \
+           node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl
+fi

--- a/test-runtime.sh
+++ b/test-runtime.sh
@@ -62,7 +62,7 @@ exec_node() { docker exec --user node "$CONTAINER" "$@"; }
 
 echo ""
 echo "=== Script presence ==="
-for script in init-firewall.sh post-create.sh post-start.sh; do
+for script in init-firewall.sh post-create.sh post-start.sh claude-sdk-fix-libc.sh; do
     if exec_root test -x "/usr/local/bin/$script"; then
         pass "$script is present and executable"
     else

--- a/test-static.sh
+++ b/test-static.sh
@@ -41,7 +41,7 @@ run "template/devcontainer.json is valid JSON" \
 echo ""
 echo "=== Script consistency ==="
 # Verify scripts referenced by devcontainer.json exist in the template.
-for script in post-create.sh post-start.sh; do
+for script in post-create.sh post-start.sh claude-sdk-fix-libc.sh; do
     run "$script exists in template" \
         test -f "template/.devcontainer/$script"
 done
@@ -108,6 +108,8 @@ run "template/post-create.sh" \
     shellcheck template/.devcontainer/post-create.sh
 run "template/post-start.sh" \
     shellcheck template/.devcontainer/post-start.sh
+run "template/claude-sdk-fix-libc.sh" \
+    shellcheck template/.devcontainer/claude-sdk-fix-libc.sh
 run "host-setup.sh" \
     shellcheck host-setup.sh
 run "test-static.sh" \


### PR DESCRIPTION
## Summary

Ship `/usr/local/bin/claude-sdk-fix-libc` so projects that depend on `@anthropic-ai/claude-agent-sdk` can work around the SDK's broken native-binary selection on glibc containers.

## Background

`@anthropic-ai/claude-agent-sdk`'s probe (`K7()` in `sdk.mjs`) unconditionally tries the musl variant first on Linux, only falling back to glibc if `require.resolve()` on the musl package throws. Combined with a manifest bug — the `linux-*-musl` packages don't declare `"libc": ["musl"]`, so npm installs them on every Linux host — this means the SDK always loads a musl-linked binary. On a glibc system (which this image always is: `FROM node:20` = Debian) the binary crashes its dynamic link on first subprocess write, producing a very unfriendly `EPIPE` on a raw Socket.

Diagnosed after the brunel REPL started failing post-container-rebuild; the standalone `claude` CLI worked fine, only the SDK-spawned subprocess died.

## What this adds

- `template/.devcontainer/claude-sdk-fix-libc.sh` — installed into `/usr/local/bin/` with +x. Removes the musl variants from `node_modules/@anthropic-ai/` so the SDK's fallback picks the glibc binary. No-op when the SDK isn't installed, so safe to call unconditionally.
- Dockerfile COPY + chmod updated to include the new script.
- Static tests pick up the new script via the existing presence + shellcheck loops; runtime test picks it up via the existing `/usr/local/bin/*.sh` presence loop.

## Usage in downstream projects

Append to `postCreateCommand`:

```jsonc
"postCreateCommand": "npm ci && claude-sdk-fix-libc"
```

## Upstream fix

This helper can be deleted once `anthropics/claude-agent-sdk-typescript` ships either libc manifests on the native packages, or a proper libc check in `K7()`. Worth filing.

## Test plan

- [x] `./test-static.sh` — 17/17 passing (hadolint, shellcheck, JSON, presence checks all green)
- [ ] `./test-runtime.sh` — requires Docker + `NET_ADMIN`, run locally before merging
- [ ] Verify in a downstream project with the SDK: `npm ci && claude-sdk-fix-libc` leaves only `claude-agent-sdk-linux-x64/` (no `-musl`) in `node_modules/@anthropic-ai/`, and the SDK query works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
