### PR TITLE
fix: install brunel from archive tarball URL to avoid npm github-install bug

### DIFF
--- a/template/.devcontainer/Dockerfile
+++ b/template/.devcontainer/Dockerfile
@@ -84,9 +84,13 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
 # hadolint ignore=DL4006,DL4001
 RUN curl -fsSL https://claude.ai/install.sh | bash -s ${CLAUDE_CODE_CHANNEL}
 
-# Install brunel (Claude Code agent shell)
+# Install brunel (Claude Code agent shell).
+# Install from a GitHub archive tarball URL rather than the `github:jasoncrawford/brunel`
+# shorthand: the shorthand uses npm's clone+pack+nested-install path, which races with
+# itself on packages with many optional native-binary deps and fails with TAR_ENTRY_ERROR.
+# The archive URL uses npm's standard tarball install path, which works reliably.
 # hadolint ignore=DL3016
-RUN npm install -g github:jasoncrawford/brunel
+RUN npm install -g https://github.com/jasoncrawford/brunel/archive/refs/heads/main.tar.gz
 
 # Copy and set up scripts
 COPY init-firewall.sh post-create.sh post-start.sh claude-sdk-fix-libc.sh /usr/local/bin/

--- a/test-static.sh
+++ b/test-static.sh
@@ -94,10 +94,10 @@ fi
 
 echo ""
 echo "=== Brunel installation ==="
-if grep -q "github:jasoncrawford/brunel" template/.devcontainer/Dockerfile; then
-    pass "Dockerfile installs brunel from GitHub"
+if grep -q "jasoncrawford/brunel/archive/refs/heads/main.tar.gz" template/.devcontainer/Dockerfile; then
+    pass "Dockerfile installs brunel from GitHub archive tarball URL"
 else
-    fail "Dockerfile does not install brunel (expected: npm install -g github:jasoncrawford/brunel)"
+    fail "Dockerfile does not install brunel (expected: install from brunel archive tarball URL)"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Fix the Publish workflow, which has been failing since `@anthropic-ai/claude-agent-sdk` 0.2.113 added 8 native-binary optional dependencies (~73MB each, ~584MB total).

## The bug

`npm install -g github:jasoncrawford/brunel` goes through npm's git-install code path:

1. Clone the repo
2. Run a nested `npm install --force --include optional` to satisfy a potential `prepare` script
3. `npm pack` the result
4. Install the packed tarball globally, which re-installs all deps

Steps 2 and 4 both extract the same set of optional native-binary tarballs concurrently into the same global location. With 8 large native packages plus the normal dep tree, the two processes race: `tar` tries to write files into directories that the other is creating or deleting, producing hundreds of `TAR_ENTRY_ERROR ENOENT` warnings on `hono/dist/types/*`, `@anthropic-ai/sdk/*`, `zod/*`, `@modelcontextprotocol/sdk/*`, and the matching-platform native binary (`claude-agent-sdk-linux-x64` on Actions, `-linux-arm64` locally). The install ends with `esbuild` postinstall failing `spawn sh ENOENT` because its cwd has been wiped out from under it.

Reproduces deterministically in a plain `node:20` container, so it's not a CI-runner thing. Last successful publish was 2026-03-13, which predates the SDK's switch from `@img/sharp-*` optional deps (in 0.2.74) to the native SDK binaries (introduced in 0.2.113).

`npm install -g` against the **npm registry** or a **tarball URL** works fine — those paths skip the nested prepare-install step. So the simplest fix is to install from the GitHub archive tarball URL instead of the `github:` shorthand.

## Change

```diff
-RUN npm install -g github:jasoncrawford/brunel
+RUN npm install -g https://github.com/jasoncrawford/brunel/archive/refs/heads/main.tar.gz
```

Same semantics (install brunel from `main`), different npm code path.

Also updates the `test-static.sh` grep that verifies the Dockerfile installs brunel.

## Test plan

- [x] `./test-static.sh` — 17/17 passing
- [x] Verified locally: `docker run --rm node:20 bash -c "npm install -g https://github.com/jasoncrawford/brunel/archive/refs/heads/main.tar.gz"` completes cleanly, only the matching glibc native binary is installed, `/usr/local/bin/brunel` is present
- [ ] Publish workflow on merge

## Followup

This is a workaround, not a proper fix. The real bug is in npm's git-install reify path; worth a minimal repro against `npm/cli`. Our upstream-fix candidate list now has two entries:

1. `anthropics/claude-agent-sdk-typescript` — missing `"libc"` manifests on musl packages + `K7()` probe tries musl first (the reason we needed `claude-sdk-fix-libc`)
2. `npm/cli` — nested `npm install` during `npm install -g github:...` races with the outer install on optional native-binary deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
