### PR TITLE
ci: add workflow_dispatch to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   publish-image:


### PR DESCRIPTION
Adds a manual trigger to the publish workflow so the image can be rebuilt (e.g. to pick up latest brunel) without needing a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)