### PR TITLE
feat: allow brunel foreman in firewall

### DIFF
--- a/template/.devcontainer/init-firewall.sh
+++ b/template/.devcontainer/init-firewall.sh
@@ -82,6 +82,7 @@ for domain in \
     "productionresultssa10.blob.core.windows.net" \
     "productionresultssa11.blob.core.windows.net" \
     "productionresultssa12.blob.core.windows.net" \
+    "brunel-production.up.railway.app" \
     ; do
     echo "Resolving $domain..."
     ips=$(dig +noall +answer A "$domain" | awk '$4 == "A" {print $5}')


### PR DESCRIPTION
brunel is installed in the base image; its foreman WebSocket endpoint (`brunel-production.up.railway.app`) needs to be reachable from the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)