### PR TITLE
Make init-firewall.sh safe to re-run

### DIFF
--- a/template/.devcontainer/init-firewall.sh
+++ b/template/.devcontainer/init-firewall.sh
@@ -14,6 +14,16 @@ iptables -t mangle -F
 iptables -t mangle -X
 ipset destroy allowed-domains 2>/dev/null || true
 
+# Reset default policies to ACCEPT. iptables -F does NOT reset policies, so
+# without this a re-run from an already-locked-down state would inherit the
+# previous DROP policy and silently block the curl to api.github.com below.
+iptables -P INPUT ACCEPT
+iptables -P FORWARD ACCEPT
+iptables -P OUTPUT ACCEPT
+ip6tables -P INPUT ACCEPT
+ip6tables -P FORWARD ACCEPT
+ip6tables -P OUTPUT ACCEPT
+
 # 2. Selectively restore ONLY internal Docker DNS resolution
 if [ -n "$DOCKER_DNS_RULES" ]; then
     echo "Restoring Docker DNS rules..."
@@ -38,7 +48,7 @@ ipset create allowed-domains hash:net
 
 # Fetch GitHub meta information and aggregate + add their IP ranges
 echo "Fetching GitHub IP ranges..."
-gh_ranges=$(curl -s https://api.github.com/meta)
+gh_ranges=$(curl -s --connect-timeout 5 --max-time 30 https://api.github.com/meta)
 if [ -z "$gh_ranges" ]; then
     echo "ERROR: Failed to fetch GitHub IP ranges"
     exit 1


### PR DESCRIPTION
## Summary

Makes `init-firewall.sh` safe to re-run inside an already-locked-down container, so that adding a new allowlisted domain doesn't require restarting the container (which kills any live agent sessions).

## The bug

Re-running `sudo /usr/local/bin/init-firewall.sh` from inside a container where the firewall had already run hangs at:

```
Fetching GitHub IP ranges...
```

Two root causes, both in the early section of the script:

1. **`iptables -F` flushes rules but does NOT reset default policies.** The previous run set `OUTPUT` policy to `DROP`. After flushing, the rule that ACCEPTed traffic to the `allowed-domains` ipset is gone, but `OUTPUT DROP` persists — so every outbound packet (including the script's own curl to `api.github.com`) is silently dropped.
2. **The `curl` to `api.github.com/meta` had no timeout.** With (1) silently dropping the SYN, the curl waited indefinitely instead of failing fast.

## Fix

- Reset all `iptables` and `ip6tables` default policies to `ACCEPT` immediately after the flush. Policies are restored to `DROP` later in the script as before.
- Add `--connect-timeout 5 --max-time 30` to the GitHub meta fetch so future failures of this kind surface in seconds, not forever.

## Test plan

- [ ] Build a devcontainer using this template
- [ ] Confirm initial `init-firewall.sh` run still works (network is locked down at the end)
- [ ] Add a new domain to `firewall-extras.txt`, run `sudo /usr/local/bin/init-firewall.sh`, confirm it completes and the new domain is reachable

## Why this matters

Without this, the only way to update the allowlist on a running devcontainer is to restart the container, which kills any in-flight Claude Code agent sessions. With it, a project can edit `firewall-extras.txt` and reload in place.

Generated with [Claude Code](https://claude.com/claude-code)
