### PR TITLE
Install Chromium system libs for Playwright

### DIFF
--- a/template/.devcontainer/Dockerfile
+++ b/template/.devcontainer/Dockerfile
@@ -5,7 +5,15 @@ ENV TZ="$TZ"
 
 ARG CLAUDE_CODE_CHANNEL=latest
 
-# Install basic development tools and iptables/ipset
+# Install basic development tools and iptables/ipset.
+#
+# The libnss3..libasound2 group is the system-library set required by
+# headless Chromium (used by Playwright/Puppeteer for browser automation,
+# visual regression testing, etc.). Playwright's `playwright install
+# chromium` only downloads the browser binary; it cannot install these
+# system .so files because the node user has no apt access at runtime,
+# and the firewall blocks deb.debian.org anyway. Baking them into the
+# image lets `playwright install chromium` produce a working browser.
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
   less \
@@ -26,6 +34,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   jq \
   nano \
   vim \
+  libnss3 \
+  libnspr4 \
+  libdbus-1-3 \
+  libatk1.0-0 \
+  libatk-bridge2.0-0 \
+  libatspi2.0-0 \
+  libcups2 \
+  libxkbcommon0 \
+  libxcomposite1 \
+  libxdamage1 \
+  libxfixes3 \
+  libxrandr2 \
+  libgbm1 \
+  libcairo2 \
+  libpango-1.0-0 \
+  libasound2 \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Ensure default node user has access to /usr/local/share


### PR DESCRIPTION
## Summary

Bakes the Chromium system-library set into the devcontainer image so projects using Playwright (or Puppeteer, or anything else that drives headless Chromium) get a working browser out of the box.

## The problem

A project using Playwright runs `npm install`, which triggers `playwright install chromium` to download the browser binary. On Linux, Chromium also needs ~16 system `.so` files (libnss3, libnspr4, libatk*, libcups2, libxkbcommon0, libgbm1, libcairo2, libpango, libasound2, etc.) that the slim `node:20` base image doesn't include.

When those libs are missing, `chromium.launch()` either hangs or fails with a missing-so error. The fix would normally be `playwright install-deps chromium`, but in this image:

1. The `node` user has no `apt` access at runtime
2. The firewall blocks `deb.debian.org`, so even with sudo it would fail
3. `postCreateCommand` runs after the firewall is up

So the libs have to be baked in at image build time.

## What this changes

Adds the Playwright Chromium system-library set to the existing `apt-get install` block in the Dockerfile. Stays in one apt layer, inherits the existing `apt-get clean` cleanup. Package list matches Playwright's install-deps target for Chromium on Debian Bookworm (the base for `node:20`).

Image size impact: ~50 MB.

## Why bake into the base image instead of per-project

Headless-browser-driven tooling is common across Claude-driven projects (visual regression, scraping, link checking, browser tests). Solving it once at the base layer means every project Just Works; the alternative is each project rediscovering the same hang.

## Discovery context

This was hit by an agent (working on the rootsofprogress.org Astro migration) trying to use a visual-diff harness inside the devcontainer. Same script ran cleanly outside the container on macOS — the macOS Playwright build is self-contained and bypasses the issue.

## Test plan

- [ ] CI passes (hadolint clean — verified locally)
- [ ] After image rebuild + container recreate, `npm install` of a Playwright project succeeds and `chromium.launch()` produces a working browser
- [ ] Image size growth is roughly 50 MB and not dramatically more

Generated with [Claude Code](https://claude.com/claude-code)
