### PR TITLE
Add brunel.dev to default firewall allowlist

### DIFF
--- a/template/.devcontainer/init-firewall.sh
+++ b/template/.devcontainer/init-firewall.sh
@@ -92,6 +92,7 @@ for domain in \
     "productionresultssa10.blob.core.windows.net" \
     "productionresultssa11.blob.core.windows.net" \
     "productionresultssa12.blob.core.windows.net" \
+    "brunel.dev" \
     "brunel-production.up.railway.app" \
     ; do
     echo "Resolving $domain..."


### PR DESCRIPTION
## Summary
- Add `brunel.dev` to the default firewall allowlist in `init-firewall.sh`
- brunel.dev is the new official Brunel foreman domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)